### PR TITLE
Add guide for multi-agent architecture

### DIFF
--- a/MULTI_AGENT_GUIDE.md
+++ b/MULTI_AGENT_GUIDE.md
@@ -1,0 +1,37 @@
+# Multi-Agent Approach for Stock Market Prediction
+
+This guide outlines how to structure a system composed of multiple AI agents to forecast stock prices. It builds on the phases described in `index.html` and extends them into a collaborative architecture.
+
+## Core Agents
+
+1. **Data Collector Agent**
+   - Collects market data using libraries such as `yfinance` or `nsepy`.
+   - Periodically updates raw datasets.
+2. **Preprocessing Agent**
+   - Cleans and normalizes data.
+   - Generates technical indicators and custom features.
+3. **Training Agent**
+   - Runs experiments with models (e.g., LSTM, N-BEATS, XGBoost).
+   - Logs results and hyperparameters.
+4. **Evaluation Agent**
+   - Performs backtesting and stress tests.
+   - Produces reports of metrics and failure cases.
+5. **Inference Agent**
+   - Deploys trained models and serves predictions via API or UI.
+6. **Monitoring Agent**
+   - Tracks live predictions versus actual results.
+   - Triggers retraining when performance degrades.
+
+## Orchestration
+
+A workflow manager (like Airflow or Prefect) coordinates the agents. Each phase of the project corresponds to one or more agents working together. The interactive roadmap in `index.html` can serve as a reference for scheduling these tasks.
+
+## Suggested Next Steps
+
+1. Implement the Data Collector Agent and store raw data under `data/raw`.
+2. Build preprocessing scripts and verify features.
+3. Develop the Training and Evaluation agents to iterate on models.
+4. Deploy the Inference agent with a simple web UI (e.g., Streamlit).
+5. Add monitoring to close the feedback loop.
+
+For detailed steps in each phase, consult the roadmap in `index.html`.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # StockmarketAIroadmap
-Buildig AI Agent for stock market prediction
+
+This repository contains an interactive roadmap (`index.html`) and documentation for building AI agents that forecast stock market prices. See `MULTI_AGENT_GUIDE.md` for an overview of how multiple agents can collaborate across data collection, preprocessing, model training and monitoring.


### PR DESCRIPTION
## Summary
- update README with reference to new guide
- add MULTI_AGENT_GUIDE to outline how multiple agents cooperate for stock prediction

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6884a7e3bef88324b50a05013c4f97fd